### PR TITLE
Restructured header/footer content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: GraalPy
 email: your-email@domain.com
 description: 
   GraalPy, the GraalVM Implementation of Python.
-  Copyright © 2018, 2023, Oracle and/or its affiliates. All rights reserved. Oracle and Java are registered trademarks. Other names may be trademarks of their respective owners.
+  Copyright © 2023, 2024, All rights reserved. Other names may be trademarks of their respective owners.
 baseurl: # the subpath of your site, e.g. /blog
 url: https://graalpy.github.io # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,21 +42,21 @@
               <h6 class="title-footer" onclick="fadeInAndOut(this)">Learn</h6>
               <div class="grow">
                 <ul class="footer-list">
-                  <li class="footer-list__item"><a href="{{ '/guides/' | relative_url }}">Documentation</a></li>
+                  <li class="footer-list__item"><a href="{{ '/reference/' | relative_url }}">Documentation</a></li>
                   <li class="footer-list__item"><a href="{{ '/guides/' | relative_url }}">Guides</a></li>
-                  <li class="footer-list__item"><a href="{{ '/docs/' | relative_url }}">Examples</a></li>
-                  <li class="footer-list__item"><a href="https://www.graalvm.org/sdk/javadoc/" target="_blank">References</a></li>
+                  <li class="footer-list__item"><a href="{{ '/examples/' | relative_url }}">Examples</a></li>
                 </ul>
               </div>
             </div>
             <div class="footer__columns-item">
-              <h6 class="title-footer" onclick="fadeInAndOut(this)">Graal Products</h6>
+              <h6 class="title-footer" onclick="fadeInAndOut(this)">More</h6>
               <div class="grow">
                 <ul class="footer-list">
-                  <li class="footer-list__item"><a href="https://graal.cloud">Graal</a></li>
-                  <li class="footer-list__item"><a href="https://graalvm.org">GraalVM</a></li>
-                  <li class="footer-list__item"><a href="https://graal.cloud/gcn">Graal Cloud Native</a></li>
-                  <li class="footer-list__item"><a href="https://graal.cloud/graalos">GraalOS</a></li>
+                  <li class="footer-list__item"><a href="#">Contributing</a></li>
+                  <li class="footer-list__item"><a href="#">Compatibility</a></li>
+                  <li class="footer-list__item"><a href="#">Release Calendar</a></li>
+                  <li class="footer-list__item"><a href="#">FAQ</a></li>
+                  <li class="footer-list__item"><a href="#">License</a></li>
                 </ul>
               </div>
             </div>
@@ -68,7 +68,7 @@
             <div class="col-sm-12">
               <p class="copyright">
                 GraalPy, the GraalVM Implementation of Python.
-                Copyright © 2018, 2023, Oracle and/or its affiliates. All rights reserved. Oracle and Java are registered trademarks. Other names may be trademarks of their respective owners.
+                Copyright © 2023, 2024. All rights reserved. Other names may be trademarks of their respective owners.
               </p>
             </div>
           </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,33 +20,19 @@
         </label>
         <ul class="menu__list">
           <li class="menu__item">
+            <a href='{{ "/getting_started/" | relative_url }}' class="menu__link">Getting Started</a>
+          </li>
+          <li class="menu__item">
             <a href='{{ "/about/" | relative_url }}' class="menu__link">About</a>
           </li>
           <li class="menu__item">
-            <a href='{{ "/docs/" | relative_url }}' class="menu__link">Docs</a>
+            <a href='{{ "/reference/" | relative_url }}' class="menu__link">Docs</a>
           </li>
           <li class="menu__item">
-            <div class="stack-container">
-              <a href="#" class="menu__link stack__header">Learn</a>
-              <div class="stack-menu-learn">
-                <div class="stack-row">
-                  <div class="stack-column">
-                    <div class="stack__item">
-                      <img src='{{ "/resources/img/header/guides.svg" | relative_url }}'>
-                      <a href='{{ "/guides/" | relative_url }}' class="item-line">Guides</a>
-                    </div>
-                    <div class="stack__item">
-                      <img src='{{ "/resources/img/header/guides.svg" | relative_url }}'>
-                      <a href='{{ "/examples/" | relative_url }}' class="item-line">Examples</a>
-                    </div>
-                    <div class="stack__item">
-                      <img src='{{ "/resources/img/header/guides.svg" | relative_url }}'>
-                      <a href='{{ "/reference/" | relative_url }}' class="item-line">References</a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <a href='{{ "/guides/" | relative_url }}' class="menu__link">Guides</a>
+          </li>
+          <li class="menu__item">
+            <a href='{{ "/examples/" | relative_url }}' class="menu__link">Examples</a>
           </li>
           <li class="menu__item">
             <div class="stack-container">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -93,9 +93,7 @@ layout: base
           <h2 class="pygetstarted__section-title">Installing GraalPy</h2>
           <h4 class="pygetstarted__section-subtitle">Linux and MacOS</h4>
           <h5 class="pygs__text">The easiest way to install GraalPy on Linux and macOS platforms is to use <a
-              class="link" href="https://github.com/pyenv/pyenv" target="_blank">pyenv </a> (the Python version manager)
-            or <a href="https://conda-forge.org/" target="_blank">Conda-Forge </a> (Conda-Forge provides GraalPy Community
-            only). For example, to install version 23.1.0 using <code class="text-code">pyenv</code>, run the following commands:</h5>
+              class="link" href="https://github.com/pyenv/pyenv" target="_blank">pyenv </a> (the Python version manager). To install version 23.1.0 using <code class="text-code">pyenv</code>, run the following commands:</h5>
           <div class="language-bash highlighter-rouge">
             <div class="highlight">
               <pre class="highlight marg-extend">
@@ -111,7 +109,7 @@ layout: base
               </pre>
             </div>
           </div>
-          <h5 class="pygs__text">For Conda-Forge, use the following command:</h5>
+          <!-- <h5 class="pygs__text">For Conda-Forge, use the following command:</h5>
           <div class="language-bash highlighter-rouge">
             <div class="highlight">
               <pre class="highlight marg-extend">
@@ -119,7 +117,7 @@ layout: base
   % conda create -c conda-forge -n graalpy graalpy</code>
               </pre>
             </div>
-          </div>
+          </div> -->
           <h5 class="pygs__text">Alternatively, download a compressed GraalPy installation file appropriate for your
             platform from <a href="https://github.com/oracle/graalpython/releases" target="_blank">Github releases</a>.
             For example, for Linux, download a file that matches the pattern <em>graalpy-XX.Y.Z-linux-amd64.tar.gz</em>.

--- a/_sass/minima/layout/_menu.scss
+++ b/_sass/minima/layout/_menu.scss
@@ -95,7 +95,7 @@ a.menu__link {
 }
 
 a.stack__header {
-    background: url("{{ '/resources/img/header/arrow-down.svg' | relative_url }}") 99% 50% no-repeat;
+    background: url("/resources/img/header/arrow-down.svg") 99% 50% no-repeat;
     padding: 5px 24px 5px 0px;
 }
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,8 +11,8 @@ permalink: /getting_started/
 ## Installing GraalPy
 
 ### Linux and macOS
-The easiest way to install GraalPy on Linux and macOS platforms is to use [Pyenv](https://github.com/pyenv/pyenv) (the Python version manager) or [Conda-Forge](https://conda-forge.org/) (Conda-Forge provides GraalPy Community only).
-For example, to install version 23.1.0 using `pyenv`, run the following commands:
+The easiest way to install GraalPy on Linux and macOS platforms is to use [Pyenv](https://github.com/pyenv/pyenv) (the Python version manager).
+To install version 23.1.0 using `pyenv`, run the following commands:
 
 ```bash
 % pyenv install graalpy-23.1.0
@@ -24,13 +24,6 @@ Installed graalpy-23.1.0 to ~/.pyenv/versions/graalpy-23.1.0
  
 % pyenv shell graalpy-23.1.0
 ```
-
-For Conda-Forge, use the following command:
-
-```bash
-% conda create -c conda-forge -n graalpy graalpy
-```
-
 
 Alternatively, download a compressed GraalPy installation file appropriate for your platform from [GitHub releases](https://github.com/oracle/graalpython/releases).
 For example, for Linux, download a file that matches the pattern _graalpy-XX.Y.Z-linux-amd64.tar.gz_.


### PR DESCRIPTION
Added new header menu items
- disbanded "Learn" item;
- added seperately "Guides", "Examples", "Get Started"
- added "Docs" with link to references.
Added new footer items: Contributing, Compatibility, Release calendar, FAQ, License. For now, without any links.